### PR TITLE
send valid JSON in error reponse

### DIFF
--- a/bearer.lua
+++ b/bearer.lua
@@ -20,7 +20,7 @@ end
 if token == nil then
     ngx.status = ngx.HTTP_UNAUTHORIZED
     ngx.header.content_type = "application/json; charset=utf-8"
-    ngx.say("{error: \"missing JWT token or Authorization header\"}")
+    ngx.say("{\"error\": \"missing JWT token or Authorization header\"}")
     ngx.exit(ngx.HTTP_UNAUTHORIZED)
 end
 
@@ -42,7 +42,7 @@ if not jwt_obj["verified"] then
     ngx.status = ngx.HTTP_UNAUTHORIZED
     ngx.log(ngx.WARN, jwt_obj.reason)
     ngx.header.content_type = "application/json; charset=utf-8"
-    ngx.say("{error: \"" .. jwt_obj.reason .. "\"}")
+    ngx.say("{\"error\": \"" .. jwt_obj.reason .. "\"}")
     ngx.exit(ngx.HTTP_UNAUTHORIZED)
 end
 


### PR DESCRIPTION
use string type for object names
see p. 3 in Ecma JSON standard
https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf